### PR TITLE
Fix mobile PDF viewer layout on small screens

### DIFF
--- a/assets/viewer.js
+++ b/assets/viewer.js
@@ -206,6 +206,13 @@ function scheduleRerender(){
 (function initSidebarToggle(){
   const shell=document.querySelector('.shell');
   async function apply(collapsed){
+    const mobile = window.matchMedia('(max-width:576px)').matches;
+    if(mobile){
+      collapsed = false;
+      els.toggleSidebar.style.display = 'none';
+    } else {
+      els.toggleSidebar.style.display = '';
+    }
     shell.classList.toggle('collapsed', collapsed);
     els.toggleSidebar.setAttribute('aria-pressed', (!collapsed).toString());
     try{ localStorage.setItem('pdfv_sidebar', collapsed?'1':'0'); }catch{}
@@ -218,6 +225,7 @@ function scheduleRerender(){
   // apply initial (does nothing harmful before pages exist)
   apply(collapsed);
   els.toggleSidebar.addEventListener('click', ()=> apply(!shell.classList.contains('collapsed')));
+  window.addEventListener('resize', ()=> apply(shell.classList.contains('collapsed')));
 })();
 
 // ----- wiring -----

--- a/view.php
+++ b/view.php
@@ -297,7 +297,9 @@ $createdDate = isset($link['created_at']) ? date('d-m-Y', strtotime($link['creat
   @media (max-width:576px){
     :root{ --sidebar-w:0; --divider-w:0; }
     .shell{ grid-template-columns:1fr; }
+    .shell.collapsed{ grid-template-columns:1fr; }
     #sidebar, .vbar{ display:none; }
+    #toggleSidebar{ display:none; }
   }
 </style>
 </head>


### PR DESCRIPTION
## Summary
- Ensure PDF remains visible when sidebar is collapsed on phones and hide the sidebar toggle button in mobile view
- Guard sidebar toggle logic in viewer.js so mobile devices ignore stored collapse state

## Testing
- `php -l view.php`
- `node --check assets/viewer.js`


------
https://chatgpt.com/codex/tasks/task_e_68aee52204cc8327ae650759b66b9179